### PR TITLE
fix: use non-capturing group to wrap multicharacter patterns

### DIFF
--- a/src/__tests__/compiler.test.tsx
+++ b/src/__tests__/compiler.test.tsx
@@ -9,12 +9,12 @@ test('basic quantifies', () => {
   expect(buildPattern(optionally('a'))).toEqual('a?');
 
   expect(buildPattern('a', oneOrMore('b'))).toEqual('ab+');
-  expect(buildPattern('a', oneOrMore('bc'))).toEqual('a(bc)+');
-  expect(buildPattern('a', oneOrMore('bc'))).toEqual('a(bc)+');
+  expect(buildPattern('a', oneOrMore('bc'))).toEqual('a(?:bc)+');
+  expect(buildPattern('a', oneOrMore('bc'))).toEqual('a(?:bc)+');
 
   expect(buildPattern('a', zeroOrMore('b'))).toEqual('ab*');
-  expect(buildPattern('a', zeroOrMore('bc'))).toEqual('a(bc)*');
-  expect(buildPattern('a', zeroOrMore('bc'))).toEqual('a(bc)*');
+  expect(buildPattern('a', zeroOrMore('bc'))).toEqual('a(?:bc)*');
+  expect(buildPattern('a', zeroOrMore('bc'))).toEqual('a(?:bc)*');
 
   expect(buildPattern(optionally('a'), 'b')).toEqual('a?b');
 

--- a/src/__tests__/quantifiers.test.tsx
+++ b/src/__tests__/quantifiers.test.tsx
@@ -1,9 +1,9 @@
 import { one, oneOrMore, optionally, zeroOrMore } from '../quantifiers';
-import { buildPattern } from '../compiler';
+import { buildPattern, buildRegex } from '../compiler';
 
 test('"oneOrMore" quantifier', () => {
   expect(buildPattern(oneOrMore('a'))).toEqual('a+');
-  expect(buildPattern(oneOrMore('ab'))).toEqual('(ab)+');
+  expect(buildPattern(oneOrMore('ab'))).toEqual('(?:ab)+');
 });
 
 test('"one" quantifier', () => {
@@ -13,10 +13,16 @@ test('"one" quantifier', () => {
 
 test('"optionally" quantifier', () => {
   expect(buildPattern(optionally('a'))).toEqual('a?');
-  expect(buildPattern(optionally('ab'))).toEqual('(ab)?');
+  expect(buildPattern(optionally('ab'))).toEqual('(?:ab)?');
 });
 
 test('"zeroOrMore" quantifier', () => {
   expect(buildPattern(zeroOrMore('a'))).toEqual('a*');
-  expect(buildPattern(zeroOrMore('ab'))).toEqual('(ab)*');
+  expect(buildPattern(zeroOrMore('ab'))).toEqual('(?:ab)*');
+});
+
+test('oneOrMore does not generate capture when grouping', () => {
+  const regex = buildRegex(oneOrMore('aa'));
+  const groups = [...'aa'.match(regex)!];
+  expect(groups).toEqual(['aa']);
 });

--- a/src/__tests__/quantifiers.test.tsx
+++ b/src/__tests__/quantifiers.test.tsx
@@ -26,3 +26,21 @@ test('oneOrMore does not generate capture when grouping', () => {
   const groups = [...'aa'.match(regex)!];
   expect(groups).toEqual(['aa']);
 });
+
+test('one does not generate capture when grouping', () => {
+  const regex = buildRegex(one('aa'));
+  const groups = [...'aa'.match(regex)!];
+  expect(groups).toEqual(['aa']);
+});
+
+test('optionally does not generate capture when grouping', () => {
+  const regex = buildRegex(optionally('aa'));
+  const groups = [...'aa'.match(regex)!];
+  expect(groups).toEqual(['aa']);
+});
+
+test('zeroOrMore does not generate capture when grouping', () => {
+  const regex = buildRegex(zeroOrMore('aa'));
+  const groups = [...'aa'.match(regex)!];
+  expect(groups).toEqual(['aa']);
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,9 @@
-export function wrapGroup(input: string): string {
-  return input.length === 1 ? input : `(${input})`;
+/**
+ * Wraps regex string in a non-capturing group if it is more than one character long.
+ *
+ * @param regex
+ * @returns
+ */
+export function wrapGroup(regex: string): string {
+  return regex.length === 1 ? regex : `(?:${regex})`;
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Use a non-capturing group to wrap multiline patterns for quantifiers. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added tests to detect capture group presence in the output.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
